### PR TITLE
Use requirements.txt as the single source of truth for Python requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.7
+COPY requirements.txt serve.py /usr/src/
 RUN python3 -m pip install --upgrade pip && \
-    python3 -m pip install requests sanic sanic-cors
-COPY serve.py /usr/src
+    python3 -m pip install -r /usr/src/requirements.txt
 CMD ["python", "/usr/src/serve.py"]

--- a/README.md
+++ b/README.md
@@ -53,3 +53,16 @@ cd redirector
 pip3.7 install -r requirements.txt
 nohup python3.7 serve.py &
 ```
+
+## Development
+
+This repo uses pre-commit for styling and syntax checks. To use in your Python
++ git environment, do:
+
+```
+pip install pre-commit
+pre-commit install
+```
+
+After this, it will run the pre-commit checks on every git commit, make any
+adjustments as necessary, and request that you git commit again.

--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ certbot --nginx
 #### make a local pip upgrade
 ```
 python3.7 -m pip install --upgrade pip
-pip3.7 install requests sanic sanic-cors
 ```
 
 #### clone repo and run
 ```
 git clone https://github.com/dandi/redirector.git
 cd redirector
+pip3.7 install -r requirements.txt
 nohup python3.7 serve.py &
 ```


### PR DESCRIPTION
This PR updates the Dockerfile and README to both refer to `requirements.txt` instead of duplicating the list of requirements.