### PR TITLE
Workflow for testing with dandi

### DIFF
--- a/.github/workflows/test-dandi.yml
+++ b/.github/workflows/test-dandi.yml
@@ -1,0 +1,36 @@
+name: Test Dandi-Cli Integration
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python:
+          - 3.6
+          - 3.7
+          - 3.8
+    steps:
+    - name: Check out source code
+      uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+    - name: Set up Python ${{ matrix.python }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install requirements
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install "dandi[test]"
+        python -m pip install -r util/rewrite-dandi-docker.req.txt
+    - name: Rewrite dandi docker-compose.py
+      run: |
+        python util/rewrite-dandi-docker.py
+    - name: Run tests
+      run: |
+        python -m pytest -s -v -k test_parse_dandi --pyargs dandi

--- a/util/rewrite-dandi-docker.py
+++ b/util/rewrite-dandi-docker.py
@@ -1,0 +1,19 @@
+#!/usr/bin/python3
+from pathlib import Path
+from importlib_resources import as_file, files
+from ruamel.yaml import YAML
+
+yaml = YAML(typ="safe")
+yaml.default_flow_style = False
+
+build_context = Path(__file__).resolve().parent.parent
+
+with as_file(
+    files("dandi") / "tests" / "data" / "dandiarchive-docker" / "docker-compose.yml"
+) as path:
+    with path.open() as fp:
+        compose = yaml.load(fp)
+    del compose["services"]["redirector"]["image"]
+    compose["services"]["redirector"]["build"] = str(build_context)
+    with path.open("w") as fp:
+        yaml.dump(compose, fp)

--- a/util/rewrite-dandi-docker.req.txt
+++ b/util/rewrite-dandi-docker.req.txt
@@ -1,0 +1,2 @@
+importlib-resources == 3.*
+ruamel.yaml ~= 0.15


### PR DESCRIPTION
Currently, this just runs the "`test_parse_dandi*`" tests because I wasn't sure what else to run.  I would prefer to specify the tests to run for this workflow via a pytest marker, but the workflow uses the last dandi release, which lacks such a marker.

Closes #29