### PR TITLE
BF: provide api with empty (null) url

### DIFF
--- a/serve.py
+++ b/serve.py
@@ -164,13 +164,13 @@ async def goto_dandiset_version(request, dataset, version):
 async def server_info(request):
     return response.json(
         {
-            "version": "1.0.0",
+            "version": "1.2.0",
             "cli-minimal-version": "0.6.0",
             "cli-bad-versions": [],
             "services": {
                 "girder": {"url": GIRDER_URL},
                 "webui": {"url": GUI_URL},
-                "api": {"url": PUBLISH_API_URL},
+                "api": {"url": None},  # Currently we use girder, not dandi-api
                 "jupyterhub": {"url": JUPYTERHUB_URL},
             },
         },

--- a/serve.py
+++ b/serve.py
@@ -15,6 +15,10 @@ GUI_URL = os.environ.get("GUI_URL", "https://gui.dandiarchive.org").rstrip("/")
 
 ABOUT_URL = os.environ.get("ABOUT_URL", "https://www.dandiarchive.org").rstrip("/")
 
+PUBLISH_API_URL = os.environ.get(
+    "PUBLISH_API_URL", "https://publish.dandiarchive.org/api"
+).rstrip()
+
 JUPYTERHUB_URL = os.environ.get(
     "JUPYTERHUB_URL", "https://hub.dandiarchive.org"
 ).rstrip()
@@ -160,12 +164,13 @@ async def goto_dandiset_version(request, dataset, version):
 async def server_info(request):
     return response.json(
         {
-            "version": "1.1.0",
+            "version": "1.0.0",
             "cli-minimal-version": "0.6.0",
             "cli-bad-versions": [],
             "services": {
                 "girder": {"url": GIRDER_URL},
                 "webui": {"url": GUI_URL},
+                "api": {"url": PUBLISH_API_URL},
                 "jupyterhub": {"url": JUPYTERHUB_URL},
             },
         },

--- a/test_serve.py
+++ b/test_serve.py
@@ -72,13 +72,13 @@ def test_server_info():
     _, r = app.test_client.get("/server-info")
     r.raise_for_status()
     assert r.json == {
-        "version": "1.0.0",
+        "version": "1.2.0",
         "cli-minimal-version": "0.6.0",
         "cli-bad-versions": [],
         "services": {
             "girder": {"url": "https://girder.dandiarchive.org"},
             "webui": {"url": "https://gui.dandiarchive.org"},
-            "api": {"url": "https://publish.dandiarchive.org/api"},
+            "api": {"url": None},
             "jupyterhub": {"url": "https://hub.dandiarchive.org"},
         },
     }

--- a/test_serve.py
+++ b/test_serve.py
@@ -72,12 +72,13 @@ def test_server_info():
     _, r = app.test_client.get("/server-info")
     r.raise_for_status()
     assert r.json == {
-        "version": "1.1.0",
+        "version": "1.0.0",
         "cli-minimal-version": "0.6.0",
         "cli-bad-versions": [],
         "services": {
             "girder": {"url": "https://girder.dandiarchive.org"},
             "webui": {"url": "https://gui.dandiarchive.org"},
+            "api": {"url": "https://publish.dandiarchive.org/api"},
             "jupyterhub": {"url": "https://hub.dandiarchive.org"},
         },
     }


### PR DESCRIPTION
"reverts" #40 
So we do not break existing/released dandi-cli (https://github.com/dandi/dandi-cli/issues/566), and to robustify client I have submitted https://github.com/dandi/dandi-cli/pull/567 .

Would be nice to have this merged asap