### PR TITLE
Fix rstrip() calls

### DIFF
--- a/serve.py
+++ b/serve.py
@@ -17,11 +17,11 @@ ABOUT_URL = os.environ.get("ABOUT_URL", "https://www.dandiarchive.org").rstrip("
 
 PUBLISH_API_URL = os.environ.get(
     "PUBLISH_API_URL", "https://publish.dandiarchive.org/api"
-).rstrip()
+).rstrip("/")
 
 JUPYTERHUB_URL = os.environ.get(
     "JUPYTERHUB_URL", "https://hub.dandiarchive.org"
-).rstrip()
+).rstrip("/")
 
 dandiset_identifier_regex = "^[0-9]{6}$"
 


### PR DESCRIPTION
All URLs read from environment variables should have trailing slashes removed, but that was not properly applied to `PUBLISH_API_URL` and `JUPYTERHUB_URL`.