### PR TITLE
Fix Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# Sanic LTS (18.12) and Alpine
-FROM sanicframework/sanic:LTS
+FROM sanicframework/sanic:20.12
 
 WORKDIR /opt
 COPY . .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests
 sanic>=20.12,<20.13
-sanic-cors
+sanic-cors~=0.10


### PR DESCRIPTION
The Docker image failed to run due to a dependency mismatch.  This PR fixes that.