### PR TITLE
Add env var for pointing Dandi integration tests to containerized redirector

### DIFF
--- a/.github/workflows/test-dandi.yml
+++ b/.github/workflows/test-dandi.yml
@@ -32,4 +32,5 @@ jobs:
         python util/rewrite-dandi-docker.py
     - name: Run tests
       run: |
-        python -m pytest -s -v -k test_parse_dandi --pyargs dandi
+        export DANDI_REDIRECTOR_BASE=http://localhost:8079
+        python -m pytest -s -v -m redirector --pyargs dandi


### PR DESCRIPTION
Closes #42.

https://github.com/dandi/dandi-cli/pull/581 must be merged & released in order for this to work.